### PR TITLE
Refactor/lighter requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,47 +1,49 @@
 {
-  "name": "dhis2-subscriptions",
-  "version": "0.0.1",
-  "description": "Subscription utils for DHIS2 instances",
-  "main": "src/cli.js",
-  "bin": {
-    "dhis2-subscriptions": "src/cli.js"
-  },
-  "scripts": {
-    "test": "jest --runInBand",
-    "build": "mkdir -p build && babel src --out-dir build && cp -a src/i18n build && mkdir -p build/resources && cp -a src/templates build && cp -a src/templates/img build/"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/EyeSeeTea/ESTools.git"
-  },
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/EyeSeeTea/ESTools/issues"
-  },
-  "homepage": "https://github.com/EyeSeeTea/ESTools#readme",
-  "dependencies": {
-    "basic-authorization-header": "^0.2.7",
-    "bluebird": "^3.5.1",
-    "ejs": "^2.6.1",
-    "lodash": "^4.17.10",
-    "micro-memoize": "^2.1.0",
-    "moment": "^2.22.2",
-    "node-fetch-polyfill": "^2.0.6",
-    "nodemailer": "^4.6.7",
-    "properties-file": "^1.0.0",
-    "request-promise": "^4.2.2",
-    "yargs": "^12.0.1"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.3",
-    "babel-loader": "^7.1.4",
-    "babel-plugin-transform-react-jsx": "^6.24.1",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-polyfill": "^6.26.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
-    "jest": "^23.4.1"
-  }
+    "name": "dhis2-subscriptions",
+    "version": "0.0.1",
+    "description": "Subscription utils for DHIS2 instances",
+    "main": "src/cli.js",
+    "bin": {
+        "dhis2-subscriptions": "src/cli.js"
+    },
+    "scripts": {
+        "test": "jest --runInBand",
+        "prettify": "prettier \"src/*.{js,jsx,ts,tsx,json,css}\" --write",
+        "build": "mkdir -p build && babel src --out-dir build && cp -a src/i18n build && mkdir -p build/resources && cp -a src/templates build && cp -a src/templates/img build/"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/EyeSeeTea/ESTools.git"
+    },
+    "author": "",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/EyeSeeTea/ESTools/issues"
+    },
+    "homepage": "https://github.com/EyeSeeTea/ESTools#readme",
+    "dependencies": {
+        "basic-authorization-header": "^0.2.7",
+        "bluebird": "^3.5.1",
+        "ejs": "^2.6.1",
+        "lodash": "^4.17.10",
+        "micro-memoize": "^2.1.0",
+        "moment": "^2.22.2",
+        "node-fetch-polyfill": "^2.0.6",
+        "nodemailer": "^4.6.7",
+        "properties-file": "^1.0.0",
+        "request-promise": "^4.2.2",
+        "yargs": "^12.0.1"
+    },
+    "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.3",
+        "babel-loader": "^7.1.4",
+        "babel-plugin-transform-react-jsx": "^6.24.1",
+        "babel-plugin-transform-runtime": "^6.23.0",
+        "babel-polyfill": "^6.26.0",
+        "babel-preset-es2015": "^6.24.1",
+        "babel-preset-stage-0": "^6.24.1",
+        "jest": "^23.4.1",
+        "prettier": "^1.19.1"
+    }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -1,22 +1,25 @@
 const request = require("request-promise");
 const basicAuth = require("basic-authorization-header");
-const { debug } = require('./helpers');
+const { debug } = require("./helpers");
 const util = require("util");
-const { merge } = require('lodash/fp');
+const { merge } = require("lodash/fp");
 
 class Dhis2Api {
     constructor(options) {
-        const {url, auth: {username, password}} = options;
+        const {
+            url,
+            auth: { username, password },
+        } = options;
         this.baseUrl = url;
         this.headers = {
-            "authorization": basicAuth(username, password),
-            "accept": "application/json",
+            authorization: basicAuth(username, password),
+            accept: "application/json",
             "content-type": "application/json",
         };
     }
 
     _getUrl(path) {
-        return this.baseUrl.replace(/\/+$/, '') + "/" + path.replace(/^\/+/, '');
+        return this.baseUrl.replace(/\/+$/, "") + "/" + path.replace(/^\/+/, "");
     }
 
     get(path, params = {}, options = {}) {

--- a/src/api.js
+++ b/src/api.js
@@ -24,9 +24,9 @@ class Dhis2Api {
 
     get(path, params = {}, options = {}) {
         const url = this._getUrl(path);
-        debug(`GET ${url}`);
+        debug(`GET ${url}` + " " + JSON.stringify(params, null, 2));
 
-        return request({
+        const response$ = request({
             method: "GET",
             url: url,
             qs: params,
@@ -34,6 +34,11 @@ class Dhis2Api {
             body: {},
             json: true,
             ...options,
+        });
+
+        return response$.then(res => {
+            debug(`Response size: ${JSON.stringify(res).length}`);
+            return res;
         });
     }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,27 +1,34 @@
 #!/usr/bin/env node
-const yargs = require('yargs');
-const helpers = require('./helpers');
-const {sendNotifications, sendNewsletters} = require('./commands');
+const yargs = require("yargs");
+const helpers = require("./helpers");
+const { sendNotifications, sendNewsletters } = require("./commands");
 
 async function main() {
     helpers.setDebug(true);
 
     return yargs
-        .help('help', 'Display this help message and exit')
-        .option('config-file', {alias: 'c', type: 'string', default: "config.json"})
-        .option('ignore-cache', {type: 'boolean', default: false})
-        .command('send-notifications', 'Send e-mail notifications on recent activity to subscribers',
-            yargs => yargs, sendNotifications)
-        .command('send-newsletters', 'Send e-mail weekly newsletter to subscribers',
-            yargs => yargs, sendNewsletters)
+        .help("help", "Display this help message and exit")
+        .option("config-file", { alias: "c", type: "string", default: "config.json" })
+        .option("ignore-cache", { type: "boolean", default: false })
+        .command(
+            "send-notifications",
+            "Send e-mail notifications on recent activity to subscribers",
+            yargs => yargs,
+            sendNotifications
+        )
+        .command(
+            "send-newsletters",
+            "Send e-mail weekly newsletter to subscribers",
+            yargs => yargs,
+            sendNewsletters
+        )
         .demandCommand()
         .strict()
         .fail((msg, err) => {
             msg && console.error(msg);
             err && console.error(err);
             process.exit(1);
-        })
-        .argv;
+        }).argv;
 }
 
 main();

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,10 +1,10 @@
 const bluebird = require("bluebird");
 const fs = require("fs");
 const util = require("util");
-const _ = require('lodash');
-const path = require('path');
+const _ = require("lodash");
+const path = require("path");
 const properties = require("properties-file");
-const moment = require('moment');
+const moment = require("moment");
 
 let DEBUG_ENABLED = false;
 
@@ -22,8 +22,8 @@ function setDebug(isEnabled) {
     DEBUG_ENABLED = isEnabled;
 }
 
-function mapPromise(values, mapper, {concurrency = 1} = {}) {
-    return bluebird.map(values, mapper, {concurrency: concurrency});
+function mapPromise(values, mapper, { concurrency = 1 } = {}) {
+    return bluebird.map(values, mapper, { concurrency: concurrency });
 }
 
 function fileRead(path, defaultValue) {
@@ -43,7 +43,7 @@ function fileWrite(path, contents) {
 function sendMessage(api, subject, body, recipients) {
     const recipientsByModel = _(recipients)
         .groupBy("type")
-        .mapValues(models => models.map(model => ({id: model.id})))
+        .mapValues(models => models.map(model => ({ id: model.id })))
         .value();
     const message = {
         subject: subject,
@@ -66,8 +66,8 @@ function getMonthDatesBetween(dateStart, dateEnd) {
     let dates = [];
 
     while (currentDate.isBefore(dateEndOfMonth)) {
-       dates.push(currentDate.clone().startOf('month'));
-       currentDate.add(1, 'month');
+        dates.push(currentDate.clone().startOf("month"));
+        currentDate.add(1, "month");
     }
 
     return dates;
@@ -75,7 +75,7 @@ function getMonthDatesBetween(dateStart, dateEnd) {
 
 function loadTranslations(directory) {
     const templateSettings = {
-        interpolate: /{{([\s\S]+?)}}/g,  /* {{variable}} */
+        interpolate: /{{([\s\S]+?)}}/g /* {{variable}} */,
     };
 
     return _(fs.readdirSync(directory))
@@ -86,7 +86,7 @@ function loadTranslations(directory) {
             const objWithTemplates = _.mapValues(obj, s => _.template(s, templateSettings));
             const t = (key, namespace = {}) =>
                 (objWithTemplates[key] || (() => `**${key}**`))(namespace);
-            const i18nObj = {t, formatDate: date => moment(date).format('L')};
+            const i18nObj = { t, formatDate: date => moment(date).format("L") };
 
             return [locale, i18nObj];
         })
@@ -94,24 +94,26 @@ function loadTranslations(directory) {
         .value();
 }
 
-function sendEmail(mailer, {subject, text, html, recipients}) {
+function sendEmail(mailer, { subject, text, html, recipients }) {
     debug("Send email to " + recipients.join(", ") + ": " + subject);
-    return mailer.sendMail({to: recipients, subject, text, html});
+    return mailer.sendMail({ to: recipients, subject, text, html });
 }
 
 function promisify(fn) {
     return (...args) =>
-        new Promise((resolve, reject) => fn(...args, (err, res) => err ? reject(err) : resolve(res)));
+        new Promise((resolve, reject) =>
+            fn(...args, (err, res) => (err ? reject(err) : resolve(res)))
+        );
 }
 
 function getNotificationSettings(user) {
     const attributeCodes = {
-        noMentionNotifications: 'user_noInterpretationMentionNotifications',
-        noNewsletters: 'user_noInterpretationSubcriptionNotifications',
+        noMentionNotifications: "user_noInterpretationMentionNotifications",
+        noNewsletters: "user_noInterpretationSubcriptionNotifications",
     };
 
     const userAttributesValuesByCode = _(user.attributeValues)
-        .map(attributeValue => [attributeValue.attribute.code, attributeValue.value === 'true'])
+        .map(attributeValue => [attributeValue.attribute.code, attributeValue.value === "true"])
         .fromPairs()
         .value();
 
@@ -120,11 +122,11 @@ function getNotificationSettings(user) {
         .value();
 }
 
-function catchWithDebug(promise, {message, defaultValue}) {
+function catchWithDebug(promise, { message, defaultValue }) {
     return promise.catch(err => {
         debug(`ERROR: ${message}: ${err}`);
         return defaultValue;
-    })
+    });
 }
 
 Object.assign(module.exports, {

--- a/src/objects-info.js
+++ b/src/objects-info.js
@@ -36,4 +36,4 @@ const objectsInfo = [
     },
 ];
 
-module.exports = {objectsInfo};
+module.exports = { objectsInfo };

--- a/src/test-helpers.js
+++ b/src/test-helpers.js
@@ -1,41 +1,51 @@
-const _ = require('lodash');
-const moment = require('moment');
+const _ = require("lodash");
+const moment = require("moment");
 
 function getBucket() {
-  return "ev-month-" + moment().format("YYYY-MM");
+    return "ev-month-" + moment().format("YYYY-MM");
 }
 
 async function createInterpretation(api, objectPath, text = "My interpretation") {
-  const bucket = getBucket();
-  const response = await api.post(`/interpretations/${objectPath}`,
-    {body: text, headers: {"content-type": "text/plain"}, resolveWithFullResponse: true});
-  const interpretationPath = response.headers.location;
-  const interpretationId = _.last(interpretationPath.split("/"));
-  return {id: interpretationId, path: interpretationPath, bucket};
+    const bucket = getBucket();
+    const response = await api.post(`/interpretations/${objectPath}`, {
+        body: text,
+        headers: { "content-type": "text/plain" },
+        resolveWithFullResponse: true,
+    });
+    const interpretationPath = response.headers.location;
+    const interpretationId = _.last(interpretationPath.split("/"));
+    return { id: interpretationId, path: interpretationPath, bucket };
 }
 
 async function createComment(api, interpretation, text = "My comment") {
-  const bucket = getBucket();
-  const response = await api.post(`/interpretations/${interpretation.id}/comments`,
-    {body: text, headers: {"content-type": "text/plain"}, resolveWithFullResponse: true});
-  const commentPath = response.headers.location;
-  const commentId = _.last(commentPath.split("/"));
-  return {id: commentId, path: commentPath, bucket};
+    const bucket = getBucket();
+    const response = await api.post(`/interpretations/${interpretation.id}/comments`, {
+        body: text,
+        headers: { "content-type": "text/plain" },
+        resolveWithFullResponse: true,
+    });
+    const commentPath = response.headers.location;
+    const commentId = _.last(commentPath.split("/"));
+    return { id: commentId, path: commentPath, bucket };
 }
 
 async function updateInterpretation(api, interpretation, text) {
-  return api.put(`/interpretations/${interpretation.id}`,
-    {body: text, headers: {"content-type": "text/plain"}});
+    return api.put(`/interpretations/${interpretation.id}`, {
+        body: text,
+        headers: { "content-type": "text/plain" },
+    });
 }
 
 async function updateComment(api, interpretation, comment, text) {
-  return api.put(`/interpretations/${interpretation.id}/comments/${comment.id}`,
-    {body: text, headers: {"content-type": "text/plain"}});
+    return api.put(`/interpretations/${interpretation.id}/comments/${comment.id}`, {
+        body: text,
+        headers: { "content-type": "text/plain" },
+    });
 }
 
 Object.assign(module.exports, {
-  createInterpretation,
-  createComment,
-  updateInterpretation,
-  updateComment,
+    createInterpretation,
+    createComment,
+    updateInterpretation,
+    updateComment,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3090,6 +3090,11 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
 pretty-format@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.2.0.tgz#3b0aaa63c018a53583373c1cb3a5d96cc5e83017"


### PR DESCRIPTION
Closes #22 

Implementation:

- Get event and interpretation subscribers so we request only the relevant users.
- Don't do interpretation/users request on empty `in` filter.
- `prettier` support added. 

Diff without prettier: https://github.com/EyeSeeTea/dhis2-newsletter/compare/914ab...refactor/lighter-requests