### PR TITLE
Fix user reference on mail notification

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -121,14 +121,14 @@ async function getNotificationMessagesForEvent(
         const i18n = await getI18n(api, user, locale);
 
         const subject = [
-            interpretation.user.displayName,
+            interpretationOrComment.user.displayName,
             i18n.t(`${event.model}_${event.type}`),
         ].join(" ");
 
         const bodyText = [
             [
-                interpretation.user.displayName,
-                `(${interpretation.user.userCredentials.username})`,
+                interpretationOrComment.user.displayName,
+                `(${interpretationOrComment.user.userCredentials.username})`,
                 i18n.t(`${event.model}_${event.type}`),
                 i18n.t("object_subscribed") + ":",
             ].join(" "),


### PR DESCRIPTION
Fixes note in https://github.com/EyeSeeTea/dhis2-newsletter/pull/33#issue-399478119

Email subject/body used `interpretation.user`, should be `interpretationOrComment.user`.